### PR TITLE
Sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,7 +282,8 @@ jobs:
           RELDATE="$(date +'%Y-%m-%d %H:%M')"
           NAME="Auto-Build $RELDATE"
           TAGNAME="autobuild-$(date +'%Y-%m-%d-%H-%M')"
-          gh release create "$TAGNAME" --target "master" --title "$NAME" artifacts/*.{zip,tar.xz}
+          (cd artifacts && sha256sum *.{zip,tar.xz} > checksums.sha256)
+          gh release create "$TAGNAME" --target "master" --title "$NAME" artifacts/*.{zip,tar.xz} artifacts/checksums.*
           echo "tag_name=${TAGNAME}" >> $GITHUB_OUTPUT
           echo "rel_date=${RELDATE}" >> $GITHUB_OUTPUT
         env:
@@ -293,6 +294,7 @@ jobs:
           shopt -s nullglob
           mkdir latest_artifacts
           ./util/repack_latest.sh latest_artifacts artifacts/*.{zip,tar.xz}
+          (cd latest_artifacts && sha256sum *.{zip,tar.xz} > checksums.sha256)
           NAME="Latest Auto-Build (${{ steps.create_release.outputs.rel_date }})"
           TAGNAME="latest"
           gh release delete --cleanup-tag --yes "$TAGNAME" || true

--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,13 @@ EOF
 
 docker run --rm -i $TTY_ARG "${UIDARGS[@]}" -v "$PWD/ffbuild":/ffbuild -v "$BUILD_SCRIPT":/build.sh "$IMAGE" bash /build.sh
 
+if [[ -n "$FFBUILD_OUTPUT_DIR" ]]; then
+    mkdir -p "$FFBUILD_OUTPUT_DIR"
+    package_variant ffbuild/prefix "$FFBUILD_OUTPUT_DIR"
+    rm -rf ffbuild
+    exit 0
+fi
+
 mkdir -p artifacts
 ARTIFACTS_PATH="$PWD/artifacts"
 BUILD_NAME="ffmpeg-$(./ffbuild/ffmpeg/ffbuild/version.sh ffbuild/ffmpeg)-${TARGET}-${VARIANT}${ADDINS_STR:+-}${ADDINS_STR}"

--- a/scripts.d/10-mingw.sh
+++ b/scripts.d/10-mingw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://git.code.sf.net/p/mingw-w64/mingw-w64.git"
-SCRIPT_COMMIT="c0313ec3381521db6c5e3aca746ff1e3e29208d7"
+SCRIPT_COMMIT="63f3f284635f4a1a09828acd2e6f6bea1eacb0e7"
 
 ffbuild_enabled() {
     [[ $TARGET == win* ]] || return -1

--- a/scripts.d/20-libiconv.sh
+++ b/scripts.d/20-libiconv.sh
@@ -16,6 +16,9 @@ ffbuild_dockerdl() {
 }
 
 ffbuild_dockerbuild() {
+    # No automake 1.17 packaged anywhere yet.
+    sed -i 's/-1.17/-1.16/' Makefile.devel
+
     (unset CC CFLAGS GMAKE && ./autogen.sh)
 
     local myconf=(

--- a/scripts.d/20-libiconv.sh
+++ b/scripts.d/20-libiconv.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://git.savannah.gnu.org/git/libiconv.git"
-SCRIPT_COMMIT="ef22b8c17144737d4c082363bd59cc0e551e77fd"
+SCRIPT_COMMIT="bc17565f9a4caca27161609c526b776287a8270e"
 
 SCRIPT_REPO2="https://git.savannah.gnu.org/git/gnulib.git"
-SCRIPT_COMMIT2="2f2a5bb27baa5623f3229a6215c4b96a573fb9ed"
+SCRIPT_COMMIT2="e9c1d94f58eaacee919bb2015da490b980a5eedf"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/25-freetype.sh
+++ b/scripts.d/25-freetype.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/freetype/freetype.git"
-SCRIPT_COMMIT="3f3e3de34ee3613d621b643c58a40b93148e0932"
+SCRIPT_COMMIT="38272bf85341348eb0a5162ba4e1c95d370f9bce"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/25-fribidi.sh
+++ b/scripts.d/25-fribidi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/fribidi/fribidi.git"
-SCRIPT_COMMIT="68162babff4f39c4e2dc164a5e825af93bda9983"
+SCRIPT_COMMIT="cfc71cda065db859d8b4f1e3c6fe5da7ab02469a"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/25-gmp.sh
+++ b/scripts.d/25-gmp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/BtbN/gmplib.git"
-SCRIPT_COMMIT="a37099c122488caf8c0afa48f21b38d8b98e7ffc"
+SCRIPT_COMMIT="b1ba93cec1d8474f3c6909ea2ba2baf5c3a9aa85"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/25-libxml2.sh
+++ b/scripts.d/25-libxml2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GNOME/libxml2.git"
-SCRIPT_COMMIT="5737466a31830c017867e3831a329c8f605c877b"
+SCRIPT_COMMIT="71c37a565d3726440aa96d648db0426deb90157b"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/25-xz.sh
+++ b/scripts.d/25-xz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/tukaani-project/xz.git"
-SCRIPT_COMMIT="dbca3d078ec581600600abebbb18769d3d713914"
+SCRIPT_COMMIT="ea21c76aa2406ba06ac154fe57741734c04f260f"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/35-fontconfig.sh
+++ b/scripts.d/35-fontconfig.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/fontconfig/fontconfig.git"
-SCRIPT_COMMIT="3bb79f0a4ac7977942d75a16a9e7ac9cb353509d"
+SCRIPT_COMMIT="cfef47622357564d804b99dbde2993ee221fa4c2"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/45-harfbuzz.sh
+++ b/scripts.d/45-harfbuzz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/harfbuzz/harfbuzz.git"
-SCRIPT_COMMIT="5e584ee7d90d767e1d68030aa2b04b950a0bc9f9"
+SCRIPT_COMMIT="b5a65e0f20c30a7f13b2f6619479a6d666e603e0"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/45-pulseaudio.sh
+++ b/scripts.d/45-pulseaudio.sh
@@ -51,8 +51,8 @@ ffbuild_dockerbuild() {
 
     rm -r "$FFBUILD_PREFIX"/share
 
-    echo "Libs.private: -ldl -lrt" >> "$FFBUILD_PREFIX"/lib/pkgconfig/libpulse.pc
-    echo "Libs.private: -ldl -lrt" >> "$FFBUILD_PREFIX"/lib/pkgconfig/libpulse-simple.pc
+    echo "Libs.private: -ldl -lrt -liconv" >> "$FFBUILD_PREFIX"/lib/pkgconfig/libpulse.pc
+    echo "Libs.private: -ldl -lrt -liconv" >> "$FFBUILD_PREFIX"/lib/pkgconfig/libpulse-simple.pc
 }
 
 ffbuild_configure() {

--- a/scripts.d/45-x11/10-xproto.sh
+++ b/scripts.d/45-x11/10-xproto.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/proto/xorgproto.git"
-SCRIPT_COMMIT="af7cb6a643db810536605feab1402654a9818569"
+SCRIPT_COMMIT="e312ab76c4d93f2e637ac0c73987b22cd43420c7"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/scripts.d/45-x11/10-xtrans.sh
+++ b/scripts.d/45-x11/10-xtrans.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxtrans.git"
-SCRIPT_COMMIT="e69d45306f38367ce3a0a5fa126beeb4e6370585"
+SCRIPT_COMMIT="e58ae2d27f7baee28319faa02b77cdc344e2f0ca"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/scripts.d/45-x11/20-libxau.sh
+++ b/scripts.d/45-x11/20-libxau.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxau.git"
-SCRIPT_COMMIT="6b2e9a63d8306282a2b384762bea004c19f301a1"
+SCRIPT_COMMIT="a9c65683e68b3a4349afee5d7673b393fb924d2e"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/scripts.d/45-x11/30-libxcb.sh
+++ b/scripts.d/45-x11/30-libxcb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxcb.git"
-SCRIPT_COMMIT="622152ee42a310876f10602601206954b8d0613e"
+SCRIPT_COMMIT="ebea71700ff10b0624ca31647f0b4e23f6ffbc68"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/scripts.d/45-x11/40-libx11.sh
+++ b/scripts.d/45-x11/40-libx11.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libx11.git"
-SCRIPT_COMMIT="5a7d94e07fc7e4a10d6399f5e44793fa0c896af6"
+SCRIPT_COMMIT="61175323a8a374aaedb139894987ddaf2bb2ba27"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/scripts.d/45-x11/50-libxrender.sh
+++ b/scripts.d/45-x11/50-libxrender.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxrender.git"
-SCRIPT_COMMIT="6663858e918923d02c466298670c992a8437a17b"
+SCRIPT_COMMIT="46e12ff9e8e4d3f0313a2f097df93dbfdc14f92f"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/scripts.d/45-x11/50-libxxf86vm.sh
+++ b/scripts.d/45-x11/50-libxxf86vm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxxf86vm.git"
-SCRIPT_COMMIT="1c93aceb217b6db55328506c271ccdded3a5a307"
+SCRIPT_COMMIT="4f7497ee3b0deb0418ce48dcd862fd6c23e20064"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/scripts.d/45-x11/60-libxv.sh
+++ b/scripts.d/45-x11/60-libxv.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxv.git"
-SCRIPT_COMMIT="fba7bf352678db2938f5a7b173d2a8823595ef3b"
+SCRIPT_COMMIT="e1cde54538060c4fd3a3d02e3d2e2b7e5da7bff9"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/scripts.d/50-aom.sh
+++ b/scripts.d/50-aom.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://aomedia.googlesource.com/aom"
-SCRIPT_COMMIT="37c5c4e6aa461b264642505a089503fa78f0bae3"
+SCRIPT_COMMIT="433be28b4f4f899f533991e2d2829dde0ab68406"
 
 ffbuild_enabled() {
     [[ $TARGET == winarm64 ]] && return -1

--- a/scripts.d/50-avisynth.sh
+++ b/scripts.d/50-avisynth.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/AviSynth/AviSynthPlus.git"
-SCRIPT_COMMIT="452cea0511397719e9d1861dc8cb47a73a591623"
+SCRIPT_COMMIT="173cae2caa260f7d7ec5fe772086e6f83a96f7f6"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/scripts.d/50-dav1d.sh
+++ b/scripts.d/50-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/dav1d.git"
-SCRIPT_COMMIT="f8d2620d82dc769833cf3e708b806ec35529b168"
+SCRIPT_COMMIT="cd5bfa124a8c3c4c41e033253a291c387aba0eb0"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-gme.sh
+++ b/scripts.d/50-gme.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/libgme/game-music-emu.git"
-SCRIPT_COMMIT="cb2c1ccc7563ed58321cc3b6b8507b9015192b80"
+SCRIPT_COMMIT="8a2a331d6da17de14a4656a6e6c6db9d2cdc3362"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-kvazaar.sh
+++ b/scripts.d/50-kvazaar.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/ultravideo/kvazaar.git"
-SCRIPT_COMMIT="6b7f065bd8c1e265b50bafa7e84248fb09a391c9"
+SCRIPT_COMMIT="dd30dd2a7ad14e8702e1b5b12bd8e3b738373cec"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-libaribcaption.sh
+++ b/scripts.d/50-libaribcaption.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/xqq/libaribcaption.git"
-SCRIPT_COMMIT="41a014d245adf66f425a8317a031477dd1f80c67"
+SCRIPT_COMMIT="27cf3cab26084d636905335d92c375ecbc3633ea"
 
 ffbuild_enabled() {
     [[ $ADDINS_STR == *4.4* ]] && return -1

--- a/scripts.d/50-libass.sh
+++ b/scripts.d/50-libass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/libass/libass.git"
-SCRIPT_COMMIT="159cefc9074a9b816d62c6b4251521ab515ecaca"
+SCRIPT_COMMIT="4d6e9ef3077fb279cab051cc00b216c5f08efb34"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-libjxl/45-brotli.sh
+++ b/scripts.d/50-libjxl/45-brotli.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/google/brotli.git"
-SCRIPT_COMMIT="841f672884d2d67aae9dcf4725860aafadc5da2b"
+SCRIPT_COMMIT="91d96d3d9353bcb47d5a6607859e51fb7e7a28f7"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-libjxl/50-libjxl.sh
+++ b/scripts.d/50-libjxl/50-libjxl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/libjxl/libjxl.git"
-SCRIPT_COMMIT="8a39b30133c880c873ca7e2bd0911f5c8dcda49f"
+SCRIPT_COMMIT="7e1d4f1770579f230625f19a2918bf9562a3d864"
 
 ffbuild_enabled() {
     [[ $ADDINS_STR == *4.4* ]] && return -1

--- a/scripts.d/50-librist/50-librist.sh
+++ b/scripts.d/50-librist/50-librist.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/rist/librist.git"
-SCRIPT_COMMIT="c526858020ce14c1ef156c0c68a655ba8dfe8b00"
+SCRIPT_COMMIT="fdd3d0c82f069406e74889e408930d179281e1e6"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-libssh.sh
+++ b/scripts.d/50-libssh.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.com/libssh/libssh-mirror.git"
-SCRIPT_COMMIT="d2e5b69b025fce75fb67a0135c4febd9711834e0"
+SCRIPT_COMMIT="49b0c859f92bb9474412933e450da26d0410fe08"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-libvpx.sh
+++ b/scripts.d/50-libvpx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libvpx"
-SCRIPT_COMMIT="6f0c446c7b88d384a1c09caf33ec132e7ee24aea"
+SCRIPT_COMMIT="8058a0b54991257a0e1a2fcf08d993a8b70c1d3a"
 
 ffbuild_enabled() {
     [[ $TARGET == winarm64 ]] && return -1

--- a/scripts.d/50-libwebp.sh
+++ b/scripts.d/50-libwebp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libwebp"
-SCRIPT_COMMIT="4c85d860ea4ebddd47e4718880036268a80c1492"
+SCRIPT_COMMIT="2af6c034ac871c967e04c8c9f8bf2dbc2e271b18"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-libzmq.sh
+++ b/scripts.d/50-libzmq.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/zeromq/libzmq.git"
-SCRIPT_COMMIT="1f7580ab7d5c2508de30ba8dcbbf2fd103daab5c"
+SCRIPT_COMMIT="34f7fa22022bed9e0e390ed3580a1c83ac4a2834"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-lilv/96-lv2.sh
+++ b/scripts.d/50-lilv/96-lv2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/lv2/lv2.git"
-SCRIPT_COMMIT="b59021e44cc39c47031c58994323ebf1a37011d1"
+SCRIPT_COMMIT="79c318c7efffeee46ed301d1fc4724ac90ff03a8"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-lilv/96-serd.sh
+++ b/scripts.d/50-lilv/96-serd.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/drobilla/serd.git"
-SCRIPT_COMMIT="0534897c68317cfc12cde0ae3af6683350fd08b0"
+SCRIPT_COMMIT="abe9a7896f1f6e6a5158c0a1d4a3f39e4538c248"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-lilv/96-zix.sh
+++ b/scripts.d/50-lilv/96-zix.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/drobilla/zix.git"
-SCRIPT_COMMIT="39e30fdc4016337c5e41413600e337879949fac5"
+SCRIPT_COMMIT="8ab9795a4c0403a88cd01874caf5f58776ae24ca"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-lilv/97-sord.sh
+++ b/scripts.d/50-lilv/97-sord.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/drobilla/sord.git"
-SCRIPT_COMMIT="af0663da39d5526b081ab6a6c791240958c7032d"
+SCRIPT_COMMIT="e1671ccdda0b501e27dd5afdbe05bb31656409a3"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-lilv/98-sratom.sh
+++ b/scripts.d/50-lilv/98-sratom.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/lv2/sratom.git"
-SCRIPT_COMMIT="18c968e208a38320cb22acd88df2b9093e1590d5"
+SCRIPT_COMMIT="2647831aa62c4b0cef27cec0eec42c5fc3ef412b"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-lilv/99-lilv.sh
+++ b/scripts.d/50-lilv/99-lilv.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/lv2/lilv.git"
-SCRIPT_COMMIT="a6bb43656b4a891c93a70772f00774579885286c"
+SCRIPT_COMMIT="e1e0b34271d1b2c478509a5d6b37d15d774a7650"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-onevpl.sh
+++ b/scripts.d/50-onevpl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/intel/libvpl.git"
-SCRIPT_COMMIT="5f6bd8a1e753c8f63a3fd8b36894d6968b808a6d"
+SCRIPT_COMMIT="025d43d086a3e663184cb49febe86152bf05409f"
 
 ffbuild_enabled() {
     [[ $TARGET == *arm64 ]] && return -1

--- a/scripts.d/50-openal.sh
+++ b/scripts.d/50-openal.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/kcat/openal-soft.git"
-SCRIPT_COMMIT="43a2a7835a5dcc815ec140100a80ef0cd836357b"
+SCRIPT_COMMIT="6118ae73c241eb3a008bfe00d07dcb07d132dd2c"
 
 ffbuild_enabled() {
     [[ $ADDINS_STR == *4.4* ]] && return -1

--- a/scripts.d/50-openh264.sh
+++ b/scripts.d/50-openh264.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/cisco/openh264.git"
-SCRIPT_COMMIT="6746bc48f1ee9b3165200a8fad329acfdf01621b"
+SCRIPT_COMMIT="423eb2c3e47009f4e631b5e413123a003fdff1ed"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-openjpeg.sh
+++ b/scripts.d/50-openjpeg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/uclouvain/openjpeg.git"
-SCRIPT_COMMIT="05de3bfdfed79f4e56d041bb970c5ec4f4c84716"
+SCRIPT_COMMIT="eb25a5ec777ff6699f4bb1187740467dcfa64dd6"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-openmpt.sh
+++ b/scripts.d/50-openmpt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://source.openmpt.org/svn/openmpt/trunk/OpenMPT"
-SCRIPT_REV="22290"
+SCRIPT_REV="22666"
 
 ffbuild_enabled() {
     [[ $TARGET == winarm64 ]] && return -1

--- a/scripts.d/50-rav1e.sh
+++ b/scripts.d/50-rav1e.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/xiph/rav1e.git"
-SCRIPT_COMMIT="0b743163beb4a981fc8855f6e44ef0662025bd4e"
+SCRIPT_COMMIT="62b4888672aa5c1c8084a8114f999c0699e08080"
 
 ffbuild_enabled() {
     [[ $TARGET == win32 ]] && return -1

--- a/scripts.d/50-sdl.sh
+++ b/scripts.d/50-sdl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/libsdl-org/SDL.git"
-SCRIPT_COMMIT="ba433e4a5d9857ff56233d20c688962c23140ef0"
+SCRIPT_COMMIT="0efb7c78294b95d62bda35d4cd18945ee578b4d8"
 SCRIPT_BRANCH="SDL2"
 
 ffbuild_enabled() {

--- a/scripts.d/50-srt.sh
+++ b/scripts.d/50-srt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/Haivision/srt.git"
-SCRIPT_COMMIT="5f16494f584e52b08a5dcdc55fe891d01d02f3a4"
+SCRIPT_COMMIT="8a89a3abbf4d3a2f7869d535349a474607ea0214"
 
 ffbuild_enabled() {
     return 0

--- a/scripts.d/50-svtav1.sh
+++ b/scripts.d/50-svtav1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.com/AOMediaCodec/SVT-AV1.git"
-SCRIPT_COMMIT="783c3f1f28957040bed221f9fe24a437d2222547"
+SCRIPT_COMMIT="39525fd6f1046f1d6400b291f5fb2a8c0ad054ad"
 
 ffbuild_enabled() {
     [[ $TARGET == win32 ]] && return -1
@@ -14,8 +14,6 @@ ffbuild_dockerdl() {
 
 ffbuild_dockerbuild() {
     mkdir build && cd build
-
-    export CFLAGS="$CFLAGS -Dav1_cospi_arr_s32_data=svt_av1_cospi_arr_s32_data"
 
     cmake -DCMAKE_TOOLCHAIN_FILE="$FFBUILD_CMAKE_TOOLCHAIN" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$FFBUILD_PREFIX" -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF -DBUILD_APPS=OFF -DENABLE_AVX512=ON ..
     make -j$(nproc)

--- a/scripts.d/50-svtav1.sh
+++ b/scripts.d/50-svtav1.sh
@@ -15,6 +15,8 @@ ffbuild_dockerdl() {
 ffbuild_dockerbuild() {
     mkdir build && cd build
 
+    export CFLAGS="$CFLAGS -Dav1_cospi_arr_s32_data=svt_av1_cospi_arr_s32_data"
+
     cmake -DCMAKE_TOOLCHAIN_FILE="$FFBUILD_CMAKE_TOOLCHAIN" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$FFBUILD_PREFIX" -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF -DBUILD_APPS=OFF -DENABLE_AVX512=ON ..
     make -j$(nproc)
     make install

--- a/scripts.d/50-svtav1.sh
+++ b/scripts.d/50-svtav1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.com/AOMediaCodec/SVT-AV1.git"
-SCRIPT_COMMIT="c642bb04462b25d0d3881494a4e2a5487460722b"
+SCRIPT_COMMIT="783c3f1f28957040bed221f9fe24a437d2222547"
 
 ffbuild_enabled() {
     [[ $TARGET == win32 ]] && return -1

--- a/scripts.d/50-vaapi/40-libdrm.sh
+++ b/scripts.d/50-vaapi/40-libdrm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/mesa/drm.git"
-SCRIPT_COMMIT="f314a43f146d2cc4a86329cf6797178aa6ae5cc4"
+SCRIPT_COMMIT="e7d4b1df2d3f675b478897ab454d635e9b4eb915"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/scripts.d/50-vaapi/50-libva.sh
+++ b/scripts.d/50-vaapi/50-libva.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/intel/libva.git"
-SCRIPT_COMMIT="25381db75af9ff7bb15eb08b4bda95d09cf669b0"
+SCRIPT_COMMIT="e4dc66b240d6d21e6546c9a21dbcfe455c8a6bff"
 
 ffbuild_enabled() {
     [[ $ADDINS_STR == *4.4* && $TARGET == win* ]] && return -1

--- a/scripts.d/50-vulkan/45-vulkan.sh
+++ b/scripts.d/50-vulkan/45-vulkan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/Vulkan-Headers.git"
-SCRIPT_COMMIT="v1.3.302"
+SCRIPT_COMMIT="v1.4.304"
 SCRIPT_TAGFILTER="v?.*.*"
 
 ffbuild_enabled() {

--- a/scripts.d/50-vulkan/50-shaderc.sh
+++ b/scripts.d/50-vulkan/50-shaderc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/google/shaderc.git"
-SCRIPT_COMMIT="9634bcd356c257e72a06bc995e1d40964d6a8375"
+SCRIPT_COMMIT="690d259384193c90c01b52288e280b05a8481121"
 
 ffbuild_enabled() {
     [[ $ADDINS_STR == *4.4* ]] && return -1

--- a/scripts.d/50-vulkan/55-spirv-cross.sh
+++ b/scripts.d/50-vulkan/55-spirv-cross.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/SPIRV-Cross.git"
-SCRIPT_COMMIT="9040e0d25dc545a6d725276bdbd0362791c81f14"
+SCRIPT_COMMIT="6173e24b31f09a0c3217103a130e74c4ddec14a6"
 
 ffbuild_enabled() {
     [[ $ADDINS_STR == *4.4* ]] && return -1

--- a/scripts.d/50-vulkan/60-libplacebo.sh
+++ b/scripts.d/50-vulkan/60-libplacebo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/libplacebo.git"
-SCRIPT_COMMIT="5788a82f459f617a999c4d56278d54d0edfc7b81"
+SCRIPT_COMMIT="056b852018db04aa2ebc0982e27713afcea8106b"
 
 ffbuild_enabled() {
     [[ $ADDINS_STR == *4.4* ]] && return -1

--- a/scripts.d/50-vvenc.sh
+++ b/scripts.d/50-vvenc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/fraunhoferhhi/vvenc.git"
-SCRIPT_COMMIT="7cf1e5ffc5aeb33b81fa9401df9fd53ef1dae6d1"
+SCRIPT_COMMIT="81a3b6c06cfa186fa2eeccf1d8975c9ed027a214"
 
 ffbuild_enabled() {
     [[ $TARGET != *32 ]] || return -1

--- a/scripts.d/50-x264.sh
+++ b/scripts.d/50-x264.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/x264.git"
-SCRIPT_COMMIT="da14df5535fd46776fb1c9da3130973295c87aca"
+SCRIPT_COMMIT="52f7694ddd35209cb95225e7acce91d8a30cb57d"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/scripts.d/50-x265.sh
+++ b/scripts.d/50-x265.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://bitbucket.org/multicoreware/x265_git.git"
-SCRIPT_COMMIT="fa2770934b8f3d88aa866c77f27cb63f69a9ed39"
+SCRIPT_COMMIT="441e1e4614a187583a7f1bf3e1739366ff40df6c"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/scripts.d/50-xvid.sh
+++ b/scripts.d/50-xvid.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://svn.xvid.org/trunk/xvidcore"
-SCRIPT_REV="2200"
+SCRIPT_REV="2202"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/scripts.d/50-zvbi.sh
+++ b/scripts.d/50-zvbi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/zapping-vbi/zvbi"
-SCRIPT_COMMIT="a48ab3a0d72efe9968ebafa34c425c892e4afa50"
+SCRIPT_COMMIT="7a76c67ac747c5f7ea0b9cd0a90b2e6688a305de"
 
 ffbuild_enabled() {
     return 0

--- a/util/update_scripts.sh
+++ b/util/update_scripts.sh
@@ -40,7 +40,7 @@ echo "Processing ${scr}"
 
         if [[ -n "${CUR_REV}" ]]; then # SVN
             echo "Checking svn rev for ${CUR_REPO}..."
-            NEW_REV="$(svn info --password="" "${CUR_REPO}" | grep ^Revision: | cut -d" " -f2 | xargs)"
+            NEW_REV="$(svn --non-interactive info --username "anonymous" --password="" "${CUR_REPO}" | grep ^Revision: | cut -d" " -f2 | xargs)"
             echo "Got ${NEW_REV} (current: ${CUR_REV})"
 
             if [[ "${NEW_REV}" != "${CUR_REV}" ]]; then


### PR DESCRIPTION
## Summary by Sourcery

Update dependencies to their latest versions, add checksums to release artifacts, and fix a build issue with libiconv on systems without automake 1.17.

Enhancements:
- Update libiconv build script to workaround the lack of automake 1.17 on some systems.

Build:
- Add checksums to release artifacts.
- Copy built packages to FFBUILD_OUTPUT_DIR if specified.